### PR TITLE
Added back compatibility with .Net 4.6.1

### DIFF
--- a/DgvFilterPopup/DgvFilterPopup.csproj
+++ b/DgvFilterPopup/DgvFilterPopup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon />
     <StartupObject />


### PR DESCRIPTION
Hi, we were using your component for a couple of custom interfaces, but your recent update to NetCore 3.1 broke compatibility with older .net framework versions.

I've added multiple target frameworks, so your project can be built for both 4.6.1 and .Net Core 3.1.
You may add more framework too in the future.